### PR TITLE
Fixing error message "property 'sthModified' of 'EasyControls3Instance' object has no setter" + adding better error message for debugging to readCurrentData

### DIFF
--- a/custom_components/EasyControls3_homeassistant/EasyControls3Instance.py
+++ b/custom_components/EasyControls3_homeassistant/EasyControls3Instance.py
@@ -58,11 +58,10 @@ class EasyControls3Instance:
                 self._parseData(response)
                 self._isAvailable = True
                 self._lastUpdate = datetime.datetime.now()
-            except:
-                LOGGER.debug("error in reading")
+            except Exception as exception:
+                LOGGER.warning(f"error in reading ({exception})")
                 if datetime.datetime.now() - self._lastUpdate > self._offlineAfter:
                     self._isAvailable = False
-            
 
     def _parseData(self, data):
         # device info
@@ -287,6 +286,10 @@ class EasyControls3Instance:
     @property
     def sthModified(self):
         return self._sthModified
+
+    @sthModified.setter
+    def sthModified(self, value):
+        self._sthModified = value
 
     @property
     def IsAvailable(self):


### PR DESCRIPTION
Error message can be observed when you enable debugging for integration and is printed every time data is read from KWL unit