### PR TITLE
Fixing error message "property 'sthModified' of 'EasyControls3Instance' object has no setter" + adding better error message for debugging to readCurrentData

### DIFF
--- a/custom_components/EasyControls3_homeassistant/EasyControls3Instance.py
+++ b/custom_components/EasyControls3_homeassistant/EasyControls3Instance.py
@@ -58,11 +58,10 @@ class EasyControls3Instance:
                 self._parseData(response)
                 self._isAvailable = True
                 self._lastUpdate = datetime.datetime.now()
-            except:
-                LOGGER.debug("error in reading")
+            except Exception as exception:
+                LOGGER.warning(f"error in reading ({exception})")
                 if datetime.datetime.now() - self._lastUpdate > self._offlineAfter:
                     self._isAvailable = False
-            
 
     def _parseData(self, data):
         # device info
@@ -287,6 +286,10 @@ class EasyControls3Instance:
     @property
     def sthModified(self):
         return self._sthModified
+
+    @sthModified.setter
+    def sthModified(self, value):
+        self._sthModified = value
 
     @property
     def IsAvailable(self):

--- a/custom_components/EasyControls3_homeassistant/EasyControls3Instance.py
+++ b/custom_components/EasyControls3_homeassistant/EasyControls3Instance.py
@@ -63,6 +63,7 @@ class EasyControls3Instance:
                 if datetime.datetime.now() - self._lastUpdate > self._offlineAfter:
                     self._isAvailable = False
 
+
     def _parseData(self, data):
         # device info
         self._deviceModel = deviceInfo["device_model_data"][data[17 * 2 + 1]]


### PR DESCRIPTION
Error (without any details in main branch unfortunately) is visible during every interaction with KWL without the fix 